### PR TITLE
fix: Update compileSdk and targetSdk to 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 
 android {
     namespace = "com.sikuai.album"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.sikuai.album"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
Updated the `compileSdk` and `targetSdk` from 34 to 36 in `app/build.gradle.kts`.

This change is required to resolve a build failure caused by dependencies (`androidx.core:core-ktx:1.17.0`) that require a newer Android API level for compilation. This aligns the project with the requirements of its dependencies.