### PR TITLE
fix: Add material dependency for XML themes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
     implementation("androidx.activity:activity-compose:1.8.1")
+    implementation("com.google.android.material:material:1.12.0")
 
     // Compose
     val composeBom = platform("androidx.compose:compose-bom:2023.10.01")


### PR DESCRIPTION
Adds the `com.google.android.material:material` dependency to `app/build.gradle.kts`.

This is required to resolve the `Theme.Material3.DayNight.NoActionBar not found` error during resource linking. The application's base XML theme requires this library, even though the UI is built entirely with Jetpack Compose.