### PR TITLE
修复了首页右下角浮动操作按钮点击后没有反应的问题。

### DIFF
--- a/app/src/main/java/com/sikuai/album/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/sikuai/album/ui/home/HomeScreen.kt
@@ -38,6 +38,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.sikuai.album.ui.navigation.Routes
 
 @OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -65,7 +66,7 @@ fun HomeScreen(
         topBar = { TopAppBar(title = { Text("相册管理") }) },
         floatingActionButton = {
             if (uiState.photos.isNotEmpty()) {
-                FloatingActionButton(onClick = { /* TODO: Navigate to preview */ }) {
+                FloatingActionButton(onClick = { navController.navigate(Routes.PREVIEW) }) {
                     Icon(Icons.Default.PlayArrow, contentDescription = "开始第一组")
                 }
             }


### PR DESCRIPTION
原因是该按钮的 onClick 事件为空，未实现导航逻辑。本次修改为按钮添加了正确的导航调用，使其能够跳转到预览页面。